### PR TITLE
[RFR] Fix data collector "reset()" function unimplemented

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,3 +5,9 @@ filter:
 
 tools:
     sensiolabs_security_checker: true
+
+build:
+    environment:
+        php:
+            ini:
+                memory_limit: "-1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/twig-bundle:${SYMFONY_VERSION}" --no-update; fi;
     - if [ "$TWIG_VERSION" != "" ]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
 
-install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+install: COMPOSER_MEMORY_LIMIT=-1 composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
     - vendor/bin/phpunit

--- a/DataCollector/ConstantCollector.php
+++ b/DataCollector/ConstantCollector.php
@@ -49,4 +49,11 @@ class ConstantCollector extends DataCollector
     {
         return 'constant_accessor.constant_collector';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+    }
 }


### PR DESCRIPTION
Fix this error :

```
Error: Class JDecool\Bundle\TwigConstantAccessorBundle\DataCollector\ConstantCollector contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Symfony\Contracts\Service\ResetInterface::reset)
```

Stack trace :
```
class JDecool\Bundle\TwigConstantAccessorBundle\DataCollector\ConstantCollector extends DataCollector
```
=>
```
abstract class Symfony\Component\HttpKernel\DataCollector\DataCollector implements DataCollectorInterface
```
=>
```
interface Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface extends ResetInterface
```
=>
```
interface Symfony\Contracts\Service\ResetInterface
{
    public function reset();
}
```